### PR TITLE
Reduce frequency of internet monitoring

### DIFF
--- a/packages/monitoring.yaml
+++ b/packages/monitoring.yaml
@@ -2,7 +2,7 @@
 # @Date:   14/06/2017 21:02
 # @Project: Ambassadr Home Automation
 # @Last modified by:   willscott
-# @Last modified time: 09/12/2017 11:18
+# @Last modified time: 09/12/2017 13:33
 
 # This package deals with internal monitoring - both inside the flat and inside the server
 
@@ -36,16 +36,14 @@ sensor:
        electricity_secret: !secret loop_secret
   - platform: speedtest
     minute:
-      - 0
-      - 30
+      - 45
     monitored_conditions:
       - download
       - upload
     server_id: 4078
   - platform: fastdotcom
     minute:
-      - 0
-      - 30
+      - 15
   - platform: statistics
     entity_id: sensor.power_usage
     name: Power Stats


### PR DESCRIPTION
Reduce network drain by reducing frequency of speedtest and fast.com monitoring to once an hour each.